### PR TITLE
delete the redundant comment of unsigning cla

### DIFF
--- a/prow/gitee-plugins/cla-euler/cla.go
+++ b/prow/gitee-plugins/cla-euler/cla.go
@@ -131,6 +131,8 @@ func (cl *cla) handle(org, repo, prAuthor string, prNumber int, currentLabes map
 	hasCLAYes := currentLabes[cfg.CLALabelYes]
 	hasCLANo := currentLabes[cfg.CLALabelNo]
 
+	deleteSignGuide(org, repo, prNumber, cl.ghc.giteeClient)
+
 	if len(unsigned) == 0 {
 		if hasCLANo {
 			if err := cl.ghc.RemoveLabel(org, repo, prNumber, cfg.CLALabelNo); err != nil {
@@ -146,6 +148,7 @@ func (cl *cla) handle(org, repo, prAuthor string, prNumber int, currentLabes map
 		}
 		return nil
 	}
+
 	if hasCLAYes {
 		if err := cl.ghc.RemoveLabel(org, repo, prNumber, cfg.CLALabelYes); err != nil {
 			log.WithError(err).Warningf("Could not remove %s label.", cfg.CLALabelYes)
@@ -157,8 +160,6 @@ func (cl *cla) handle(org, repo, prAuthor string, prNumber int, currentLabes map
 			log.WithError(err).Warningf("Could not add %s label.", cfg.CLALabelNo)
 		}
 	}
-
-	deleteSignGuide(org, repo, prNumber, cl.ghc.giteeClient)
 
 	return cl.ghc.CreateComment(
 		org, repo, prNumber,

--- a/prow/gitee-plugins/cla/cla.go
+++ b/prow/gitee-plugins/cla/cla.go
@@ -129,6 +129,8 @@ func (cl *cla) handle(org, repo, prAuthor string, prNumber int, currentLabes map
 	hasCLAYes := currentLabes[cfg.CLALabelYes]
 	hasCLANo := currentLabes[cfg.CLALabelNo]
 
+	deleteSignGuide(org, repo, prNumber, cl.ghc.giteeClient)
+
 	if len(unsigned) == 0 {
 		if hasCLANo {
 			if err := cl.ghc.RemoveLabel(org, repo, prNumber, cfg.CLALabelNo); err != nil {
@@ -156,8 +158,6 @@ func (cl *cla) handle(org, repo, prAuthor string, prNumber int, currentLabes map
 			log.WithError(err).Warningf("Could not add %s label.", cfg.CLALabelNo)
 		}
 	}
-
-	deleteSignGuide(org, repo, prNumber, cl.ghc.giteeClient)
 
 	return cl.ghc.CreateComment(
 		org, repo, prNumber,


### PR DESCRIPTION
At present, the comment of unsigning CLA will be added when it happens. But the unsigning comment will not be deleted when the CLA checkinig is passed next time.