### PR TITLE
suggest approvers, reviewers and apply lgtm, approve label based on file owners

### DIFF
--- a/prow/gitee-plugins/review-trigger/BUILD.bazel
+++ b/prow/gitee-plugins/review-trigger/BUILD.bazel
@@ -25,7 +25,7 @@ go_library(
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",
-        "//prow/plugins/approve/approvers:go_default_library",
+        "//prow/gitee-plugins/review-trigger/approvers:go_default_library",
         "//prow/repoowners:go_default_library",
         "@com_github_huaweicloud_golangsdk//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/prow/gitee-plugins/review-trigger/approver-helper.go
+++ b/prow/gitee-plugins/review-trigger/approver-helper.go
@@ -38,8 +38,8 @@ func (ah approverHelper) suggestApprovers() []string {
 
 	if ah.numberOfApprovers == 1 {
 		ap := approvers.NewApprovers(owner)
-		ap.AddAssignees(assignees1.List()...)
-		ap.AddApprovers(currentApprovers1.List())
+		ap.AddAssignees(assignees1.UnsortedList()...)
+		ap.AddApprovers(currentApprovers1.UnsortedList())
 		return ap.GetCCs()
 	}
 
@@ -65,7 +65,7 @@ func (ah approverHelper) suggestApprovers() []string {
 		}
 	}
 	keepAssignees := ah.keepCoveringApprovers(
-		owner, fullReverseMap, approversAndSuggested, everyone.List(),
+		owner, fullReverseMap, approversAndSuggested, everyone.UnsortedList(),
 	)
 
 	return suggested.Union(keepAssignees).List()
@@ -109,7 +109,7 @@ func (ah approverHelper) keepCoveringApprovers(owner approvers.Owners, reverseMa
 		}
 
 		keptApprovers := sets.NewString()
-		for _, suggestedApprover := range owner.GetSuggestedApprovers(reverseMap, candidates).List() {
+		for suggestedApprover := range owner.GetSuggestedApprovers(reverseMap, candidates) {
 			if reverseMap[suggestedApprover].Intersection(unapproved).Len() != 0 {
 				keptApprovers.Insert(suggestedApprover)
 			}
@@ -119,7 +119,7 @@ func (ah approverHelper) keepCoveringApprovers(owner approvers.Owners, reverseMa
 	}
 
 	ap := approvers.NewApprovers(owner)
-	ap.AddApprovers(knownApprovers.List())
+	ap.AddApprovers(knownApprovers.UnsortedList())
 
 	r := sets.NewString()
 	for i := 0; i < numberOfApprovers; i++ {
@@ -129,8 +129,7 @@ func (ah approverHelper) keepCoveringApprovers(owner approvers.Owners, reverseMa
 		}
 
 		r = r.Union(v)
-
-		ap.AddApprovers(v.List())
+		ap.AddApprovers(v.UnsortedList())
 	}
 
 	return r

--- a/prow/gitee-plugins/review-trigger/approver-helper.go
+++ b/prow/gitee-plugins/review-trigger/approver-helper.go
@@ -39,9 +39,7 @@ func (ah approverHelper) suggestApprovers() []string {
 	if ah.numberOfApprovers == 1 {
 		ap := approvers.NewApprovers(owner)
 		ap.AddAssignees(assignees1.List()...)
-		for item := range currentApprovers1 {
-			ap.AddApprover(item, "", false)
-		}
+		ap.AddApprovers(currentApprovers1.List())
 		return ap.GetCCs()
 	}
 
@@ -121,9 +119,7 @@ func (ah approverHelper) keepCoveringApprovers(owner approvers.Owners, reverseMa
 	}
 
 	ap := approvers.NewApprovers(owner)
-	for k := range knownApprovers {
-		ap.AddApprover(k, "", false)
-	}
+	ap.AddApprovers(knownApprovers.List())
 
 	r := sets.NewString()
 	for i := 0; i < numberOfApprovers; i++ {
@@ -134,9 +130,7 @@ func (ah approverHelper) keepCoveringApprovers(owner approvers.Owners, reverseMa
 
 		r = r.Union(v)
 
-		for k := range v {
-			ap.AddApprover(k, "", false)
-		}
+		ap.AddApprovers(v.List())
 	}
 
 	return r

--- a/prow/gitee-plugins/review-trigger/approver-helper.go
+++ b/prow/gitee-plugins/review-trigger/approver-helper.go
@@ -38,8 +38,8 @@ func (ah approverHelper) suggestApprovers() []string {
 
 	if ah.numberOfApprovers == 1 {
 		ap := approvers.NewApprovers(owner)
-		ap.AddAssignees(assignees1.UnsortedList()...)
-		ap.AddApprovers(currentApprovers1.UnsortedList())
+		ap.AddAssignee(assignees1.UnsortedList()...)
+		ap.AddApprover(currentApprovers1.UnsortedList()...)
 		return ap.GetCCs()
 	}
 
@@ -85,7 +85,7 @@ func removeSliceElement(v []string, target string) []string {
 func (ah approverHelper) keepCoveringApprovers(owner approvers.Owners, reverseMap map[string]sets.String, knownApprovers sets.String, potentialApprovers []string) sets.String {
 	numberOfApprovers := ah.numberOfApprovers
 
-	f := func(ap approvers.Approvers) sets.String {
+	f := func(ap *approvers.StaticApprovers) sets.String {
 		excludedApprovers := sets.String{}
 		unapproved := sets.String{}
 		files := ap.GetFilesApprovers()
@@ -118,8 +118,7 @@ func (ah approverHelper) keepCoveringApprovers(owner approvers.Owners, reverseMa
 		return keptApprovers
 	}
 
-	ap := approvers.NewApprovers(owner)
-	ap.AddApprovers(knownApprovers.UnsortedList())
+	ap := approvers.NewStaticApprovers(owner, knownApprovers.UnsortedList())
 
 	r := sets.NewString()
 	for i := 0; i < numberOfApprovers; i++ {
@@ -129,7 +128,7 @@ func (ah approverHelper) keepCoveringApprovers(owner approvers.Owners, reverseMa
 		}
 
 		r = r.Union(v)
-		ap.AddApprovers(v.UnsortedList())
+		ap.AddApprover(v.UnsortedList()...)
 	}
 
 	return r

--- a/prow/gitee-plugins/review-trigger/approver-helper.go
+++ b/prow/gitee-plugins/review-trigger/approver-helper.go
@@ -4,7 +4,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"k8s.io/test-infra/prow/plugins/approve/approvers"
+	"k8s.io/test-infra/prow/gitee-plugins/review-trigger/approvers"
 )
 
 type approverHelper struct {
@@ -47,7 +47,7 @@ func (ah approverHelper) suggestApprovers() []string {
 
 	approversAndAssignees := currentApprovers1.Union(assignees1)
 	randomizedApprovers := owner.GetShuffledApprovers()
-	leafReverseMap := owner.GetReverseMap(owner.GetLeafApprovers())
+	leafReverseMap := approvers.GetReverseMap(owner.GetLeafApprovers())
 	if dontAllowSelfApprove {
 		if _, ok := leafReverseMap[prAuthor]; ok {
 			delete(leafReverseMap, prAuthor)
@@ -60,7 +60,7 @@ func (ah approverHelper) suggestApprovers() []string {
 
 	approversAndSuggested := currentApprovers1.Union(suggested)
 	everyone := approversAndSuggested.Union(assignees1)
-	fullReverseMap := owner.GetReverseMap(owner.GetApprovers())
+	fullReverseMap := approvers.GetReverseMap(owner.GetApprovers())
 	if dontAllowSelfApprove {
 		if _, ok := fullReverseMap[prAuthor]; ok {
 			delete(fullReverseMap, prAuthor)

--- a/prow/gitee-plugins/review-trigger/approvers/BUILD.bazel
+++ b/prow/gitee-plugins/review-trigger/approvers/BUILD.bazel
@@ -4,8 +4,8 @@ go_library(
     name = "go_default_library",
     srcs = [
         "approvers.go",
-        "approvers_helper.go",
         "owners.go",
+        "static_approvers.go",
     ],
     importpath = "k8s.io/test-infra/prow/gitee-plugins/review-trigger/approvers",
     visibility = ["//visibility:public"],

--- a/prow/gitee-plugins/review-trigger/approvers/BUILD.bazel
+++ b/prow/gitee-plugins/review-trigger/approvers/BUILD.bazel
@@ -1,0 +1,42 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "approvers.go",
+        "owners.go",
+    ],
+    importpath = "k8s.io/test-infra/prow/gitee-plugins/review-trigger/approvers",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "approvers_test.go",
+        "owners_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/gitee-plugins/review-trigger/approvers/BUILD.bazel
+++ b/prow/gitee-plugins/review-trigger/approvers/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "approvers.go",
+        "approvers_helper.go",
         "owners.go",
     ],
     importpath = "k8s.io/test-infra/prow/gitee-plugins/review-trigger/approvers",

--- a/prow/gitee-plugins/review-trigger/approvers/approvers.go
+++ b/prow/gitee-plugins/review-trigger/approvers/approvers.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package approvers
 
 import (
@@ -90,19 +106,13 @@ func (ap Approvers) GetCurrentApproversSetCased() sets.String {
 }
 
 // AreFilesApproved returns a bool indicating whether or not OWNERS files associated with
-// the PR are approved.  A PR with no OWNERS files is not considered approved. If this
-// returns true, the PR may still not be fully approved depending on the associated issue
-// requirement
+// the PR are approved.  A PR with no OWNERS files is not considered approved.
 func (ap Approvers) AreFilesApproved() bool {
 	return len(ap.owners.filenames) != 0 && ap.UnapprovedFiles().Len() == 0
 }
 
 // RequirementsMet returns a bool indicating whether the PR has met all approval requirements:
 // - all OWNERS files associated with the PR have been approved AND
-// EITHER
-// 	- the munger config is such that an issue is not required to be associated with the PR
-// 	- that there is an associated issue with the PR
-// 	- an OWNER has indicated that the PR is trivial enough that an issue need not be associated with the PR
 func (ap Approvers) RequirementsMet() bool {
 	return ap.AreFilesApproved()
 }

--- a/prow/gitee-plugins/review-trigger/approvers/approvers.go
+++ b/prow/gitee-plugins/review-trigger/approvers/approvers.go
@@ -1,0 +1,113 @@
+package approvers
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// NewApprovers create a new "Approvers" with no approval.
+func NewApprovers(owners Owners) Approvers {
+	return Approvers{
+		owners:    owners,
+		approvers: sets.NewString(),
+		assignees: sets.NewString(),
+	}
+}
+
+// Approvers is struct that provide functionality with regard to approvals of a specific
+// code change.
+type Approvers struct {
+	owners    Owners
+	approvers sets.String // The keys of this map are normalized to lowercase.
+	assignees sets.String
+}
+
+// GetCCs gets the list of suggested approvers for a pull-request.  It
+// now considers current assignees as potential approvers. Here is how
+// it works:
+// - We find suggested approvers from all potential approvers, but
+// remove those that are not useful considering current approvers and
+// assignees. This only uses leaf approvers to find the closest
+// approvers to the changes.
+// - We find a subset of suggested approvers from current
+// approvers, suggested approvers and assignees, but we remove those
+// that are not useful considering suggested approvers and current
+// approvers. This uses the full approvers list, and will result in root
+// approvers to be suggested when they are assigned.
+// We return the union of the two sets: suggested and suggested
+// assignees.
+// The goal of this second step is to only keep the assignees that are
+// the most useful.
+func (ap Approvers) GetCCs() []string {
+	currentApprovers := ap.GetCurrentApproversSet()
+
+	approversAndAssignees := currentApprovers.Union(ap.assignees)
+	randomizedApprovers := ap.owners.GetShuffledApprovers()
+	leafReverseMap := GetReverseMap(ap.owners.GetLeafApprovers())
+	suggested := ap.owners.KeepCoveringApprovers(leafReverseMap, approversAndAssignees, randomizedApprovers)
+
+	approversAndSuggested := currentApprovers.Union(suggested)
+	everyone := approversAndSuggested.Union(ap.assignees)
+	fullReverseMap := GetReverseMap(ap.owners.GetApprovers())
+	keepAssignees := ap.owners.KeepCoveringApprovers(fullReverseMap, approversAndSuggested, everyone.List())
+
+	return suggested.Union(keepAssignees).List()
+}
+
+// GetCurrentApproversSet returns the set of approvers (login only, normalized to lower case)
+func (ap Approvers) GetCurrentApproversSet() sets.String {
+	return ap.approvers
+}
+
+// AddApprover adds a new Approver
+func (ap *Approvers) AddApprover(login, reference string, noIssue bool) {
+	ap.approvers.Insert(login)
+}
+
+// UnapprovedFiles returns owners files that still need approval
+func (ap Approvers) UnapprovedFiles() sets.String {
+	unapproved := sets.NewString()
+	for fn, approvers := range ap.GetFilesApprovers() {
+		if len(approvers) == 0 {
+			unapproved.Insert(fn)
+		}
+	}
+	return unapproved
+}
+
+// GetFilesApprovers returns a map from files -> list of current approvers.
+func (ap Approvers) GetFilesApprovers() map[string]sets.String {
+	filesApprovers := map[string]sets.String{}
+	currentApprovers := ap.GetCurrentApproversSetCased()
+	for fn, potentialApprovers := range ap.owners.GetApprovers() {
+		filesApprovers[fn] = currentApprovers.Intersection(potentialApprovers)
+	}
+	return filesApprovers
+}
+
+// GetCurrentApproversSetCased returns the set of approvers logins with the original cases.
+func (ap Approvers) GetCurrentApproversSetCased() sets.String {
+	return ap.approvers
+}
+
+// AreFilesApproved returns a bool indicating whether or not OWNERS files associated with
+// the PR are approved.  A PR with no OWNERS files is not considered approved. If this
+// returns true, the PR may still not be fully approved depending on the associated issue
+// requirement
+func (ap Approvers) AreFilesApproved() bool {
+	return len(ap.owners.filenames) != 0 && ap.UnapprovedFiles().Len() == 0
+}
+
+// RequirementsMet returns a bool indicating whether the PR has met all approval requirements:
+// - all OWNERS files associated with the PR have been approved AND
+// EITHER
+// 	- the munger config is such that an issue is not required to be associated with the PR
+// 	- that there is an associated issue with the PR
+// 	- an OWNER has indicated that the PR is trivial enough that an issue need not be associated with the PR
+func (ap Approvers) RequirementsMet() bool {
+	return ap.AreFilesApproved()
+}
+
+// AddAssignees adds assignees to the list
+func (ap *Approvers) AddAssignees(logins ...string) {
+	ap.assignees.Insert(logins...)
+}

--- a/prow/gitee-plugins/review-trigger/approvers/approvers.go
+++ b/prow/gitee-plugins/review-trigger/approvers/approvers.go
@@ -79,45 +79,6 @@ func (ap *Approvers) AddApprover(login ...string) {
 	ap.approvers.Insert(login...)
 }
 
-// UnapprovedFiles returns owners files that still need approval
-func (ap Approvers) UnapprovedFiles() sets.String {
-	unapproved := sets.NewString()
-	for fn, approvers := range ap.GetFilesApprovers() {
-		if approvers.Len() == 0 {
-			unapproved.Insert(fn)
-		}
-	}
-	return unapproved
-}
-
-// GetFilesApprovers returns a map from files -> list of current approvers.
-func (ap Approvers) GetFilesApprovers() map[string]sets.String {
-	currentApprovers := ap.GetCurrentApproversSetCased()
-
-	filesApprovers := map[string]sets.String{}
-	for fn, potentialApprovers := range ap.owners.GetApprovers() {
-		filesApprovers[fn] = currentApprovers.Intersection(potentialApprovers)
-	}
-	return filesApprovers
-}
-
-// GetCurrentApproversSetCased returns the set of approvers logins with the original cases.
-func (ap Approvers) GetCurrentApproversSetCased() sets.String {
-	return ap.approvers
-}
-
-// AreFilesApproved returns a bool indicating whether or not OWNERS files associated with
-// the PR are approved.  A PR with no OWNERS files is not considered approved.
-func (ap Approvers) AreFilesApproved() bool {
-	return len(ap.owners.filenames) != 0 && ap.UnapprovedFiles().Len() == 0
-}
-
-// RequirementsMet returns a bool indicating whether the PR has met all approval requirements:
-// - all OWNERS files associated with the PR have been approved AND
-func (ap Approvers) RequirementsMet() bool {
-	return ap.AreFilesApproved()
-}
-
 // AddAssignee adds assignees to the list
 func (ap *Approvers) AddAssignee(logins ...string) {
 	ap.assignees.Insert(logins...)

--- a/prow/gitee-plugins/review-trigger/approvers/approvers.go
+++ b/prow/gitee-plugins/review-trigger/approvers/approvers.go
@@ -75,15 +75,20 @@ func (ap Approvers) GetCurrentApproversSet() sets.String {
 }
 
 // AddApprover adds a new Approver
-func (ap *Approvers) AddApprover(login, reference string, noIssue bool) {
+func (ap *Approvers) AddApprover(login string) {
 	ap.approvers.Insert(login)
+}
+
+// AddApprovers adds approvers
+func (ap *Approvers) AddApprovers(login []string) {
+	ap.approvers.Insert(login...)
 }
 
 // UnapprovedFiles returns owners files that still need approval
 func (ap Approvers) UnapprovedFiles() sets.String {
 	unapproved := sets.NewString()
 	for fn, approvers := range ap.GetFilesApprovers() {
-		if len(approvers) == 0 {
+		if approvers.Len() == 0 {
 			unapproved.Insert(fn)
 		}
 	}
@@ -92,8 +97,9 @@ func (ap Approvers) UnapprovedFiles() sets.String {
 
 // GetFilesApprovers returns a map from files -> list of current approvers.
 func (ap Approvers) GetFilesApprovers() map[string]sets.String {
-	filesApprovers := map[string]sets.String{}
 	currentApprovers := ap.GetCurrentApproversSetCased()
+
+	filesApprovers := map[string]sets.String{}
 	for fn, potentialApprovers := range ap.owners.GetApprovers() {
 		filesApprovers[fn] = currentApprovers.Intersection(potentialApprovers)
 	}

--- a/prow/gitee-plugins/review-trigger/approvers/approvers.go
+++ b/prow/gitee-plugins/review-trigger/approvers/approvers.go
@@ -75,12 +75,7 @@ func (ap Approvers) GetCurrentApproversSet() sets.String {
 }
 
 // AddApprover adds a new Approver
-func (ap *Approvers) AddApprover(login string) {
-	ap.approvers.Insert(login)
-}
-
-// AddApprovers adds approvers
-func (ap *Approvers) AddApprovers(login []string) {
+func (ap *Approvers) AddApprover(login ...string) {
 	ap.approvers.Insert(login...)
 }
 
@@ -123,7 +118,7 @@ func (ap Approvers) RequirementsMet() bool {
 	return ap.AreFilesApproved()
 }
 
-// AddAssignees adds assignees to the list
-func (ap *Approvers) AddAssignees(logins ...string) {
+// AddAssignee adds assignees to the list
+func (ap *Approvers) AddAssignee(logins ...string) {
 	ap.assignees.Insert(logins...)
 }

--- a/prow/gitee-plugins/review-trigger/approvers/approvers.go
+++ b/prow/gitee-plugins/review-trigger/approvers/approvers.go
@@ -64,7 +64,7 @@ func (ap Approvers) GetCCs() []string {
 	approversAndSuggested := currentApprovers.Union(suggested)
 	everyone := approversAndSuggested.Union(ap.assignees)
 	fullReverseMap := GetReverseMap(ap.owners.GetApprovers())
-	keepAssignees := ap.owners.KeepCoveringApprovers(fullReverseMap, approversAndSuggested, everyone.List())
+	keepAssignees := ap.owners.KeepCoveringApprovers(fullReverseMap, approversAndSuggested, everyone.UnsortedList())
 
 	return suggested.Union(keepAssignees).List()
 }

--- a/prow/gitee-plugins/review-trigger/approvers/approvers.go
+++ b/prow/gitee-plugins/review-trigger/approvers/approvers.go
@@ -16,9 +16,7 @@ limitations under the License.
 
 package approvers
 
-import (
-	"k8s.io/apimachinery/pkg/util/sets"
-)
+import "k8s.io/apimachinery/pkg/util/sets"
 
 // NewApprovers create a new "Approvers" with no approval.
 func NewApprovers(owners Owners) Approvers {
@@ -75,8 +73,8 @@ func (ap Approvers) GetCurrentApproversSet() sets.String {
 }
 
 // AddApprover adds a new Approver
-func (ap *Approvers) AddApprover(login ...string) {
-	ap.approvers.Insert(login...)
+func (ap *Approvers) AddApprover(logins ...string) {
+	ap.approvers.Insert(logins...)
 }
 
 // AddAssignee adds assignees to the list

--- a/prow/gitee-plugins/review-trigger/approvers/approvers_helper.go
+++ b/prow/gitee-plugins/review-trigger/approvers/approvers_helper.go
@@ -1,0 +1,49 @@
+package approvers
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type approversHelper struct {
+	fileApprovers map[string]sets.String
+	approvers     sets.String
+}
+
+func newApproversHelper(o Owners, as []string) *approversHelper {
+	return &approversHelper{
+		fileApprovers: o.GetApprovers(),
+		approvers:     sets.NewString(as...),
+	}
+}
+
+func (ap *approversHelper) addApprover(a string) {
+	ap.approvers.Insert(a)
+}
+
+func (ap approversHelper) requirementsMet() bool {
+	return len(ap.fileApprovers) > 0 && ap.unapprovedFiles().Len() == 0
+}
+
+func (ap approversHelper) unapprovedFiles() sets.String {
+	unapproved := sets.NewString()
+	for fn, approvers := range ap.getFilesApprovers() {
+		if approvers.Len() == 0 {
+			unapproved.Insert(fn)
+		}
+	}
+	return unapproved
+}
+
+func (ap approversHelper) getFilesApprovers() map[string]sets.String {
+	currentApprovers := ap.getCurrentApproversSet()
+
+	filesApprovers := map[string]sets.String{}
+	for fn, potentialApprovers := range ap.fileApprovers {
+		filesApprovers[fn] = currentApprovers.Intersection(potentialApprovers)
+	}
+	return filesApprovers
+}
+
+func (ap approversHelper) getCurrentApproversSet() sets.String {
+	return ap.approvers
+}

--- a/prow/gitee-plugins/review-trigger/approvers/owners.go
+++ b/prow/gitee-plugins/review-trigger/approvers/owners.go
@@ -79,9 +79,8 @@ func (o Owners) GetAllPotentialApprovers() []string {
 // temporaryUnapprovedFiles returns the list of files that wouldn't be
 // approved by the given set of approvers.
 func (o Owners) temporaryUnapprovedFiles(approvers sets.String) sets.String {
-	ap := NewApprovers(o)
-	ap.AddApprovers(approvers.UnsortedList())
-	return ap.UnapprovedFiles()
+	ap := newApproversHelper(o, approvers.UnsortedList())
+	return ap.unapprovedFiles()
 }
 
 // KeepCoveringApprovers finds who we should keep as suggested approvers given a pre-selection
@@ -118,16 +117,16 @@ func findMostCoveringApprover(allApprovers []string, reverseMap map[string]sets.
 // GetSuggestedApprovers solves the exact cover problem, finding an approver capable of
 // approving every OWNERS file in the PR
 func (o Owners) GetSuggestedApprovers(reverseMap map[string]sets.String, potentialApprovers []string) sets.String {
-	ap := NewApprovers(o)
-	for !ap.RequirementsMet() {
-		newApprover := findMostCoveringApprover(potentialApprovers, reverseMap, ap.UnapprovedFiles())
+	ap := newApproversHelper(o, nil)
+	for !ap.requirementsMet() {
+		newApprover := findMostCoveringApprover(potentialApprovers, reverseMap, ap.unapprovedFiles())
 		if newApprover == "" {
-			o.log.Warnf("Couldn't find/suggest approvers for each files. Unapproved: %q", ap.UnapprovedFiles().UnsortedList())
-			return ap.GetCurrentApproversSet()
+			o.log.Warnf("Couldn't find/suggest approvers for each files. Unapproved: %q", ap.unapprovedFiles().UnsortedList())
+			return ap.getCurrentApproversSet()
 		}
-		ap.AddApprover(newApprover)
+		ap.addApprover(newApprover)
 	}
-	return ap.GetCurrentApproversSet()
+	return ap.getCurrentApproversSet()
 }
 
 // GetShuffledApprovers shuffles the potential approvers so that we don't

--- a/prow/gitee-plugins/review-trigger/approvers/owners.go
+++ b/prow/gitee-plugins/review-trigger/approvers/owners.go
@@ -50,22 +50,18 @@ type Owners struct {
 // GetApprovers returns a map from ownersFiles -> people that are approvers in them
 func (o Owners) GetApprovers() map[string]sets.String {
 	ownersToApprovers := map[string]sets.String{}
-
 	for _, fn := range o.filenames {
 		ownersToApprovers[fn] = o.repo.Approvers(fn)
 	}
-
 	return ownersToApprovers
 }
 
 // GetLeafApprovers returns a map from ownersFiles -> people that are approvers in them (only the leaf)
 func (o Owners) GetLeafApprovers() map[string]sets.String {
 	ownersToApprovers := map[string]sets.String{}
-
 	for _, fn := range o.filenames {
 		ownersToApprovers[fn] = o.repo.LeafApprovers(fn)
 	}
-
 	return ownersToApprovers
 }
 

--- a/prow/gitee-plugins/review-trigger/approvers/owners.go
+++ b/prow/gitee-plugins/review-trigger/approvers/owners.go
@@ -79,7 +79,7 @@ func (o Owners) GetAllPotentialApprovers() []string {
 // temporaryUnapprovedFiles returns the list of files that wouldn't be
 // approved by the given set of approvers.
 func (o Owners) temporaryUnapprovedFiles(approvers sets.String) sets.String {
-	ap := newApproversHelper(o, approvers.UnsortedList())
+	ap := NewStaticApprovers(o, approvers.UnsortedList())
 	return ap.unapprovedFiles()
 }
 
@@ -117,14 +117,14 @@ func findMostCoveringApprover(allApprovers []string, reverseMap map[string]sets.
 // GetSuggestedApprovers solves the exact cover problem, finding an approver capable of
 // approving every OWNERS file in the PR
 func (o Owners) GetSuggestedApprovers(reverseMap map[string]sets.String, potentialApprovers []string) sets.String {
-	ap := newApproversHelper(o, nil)
+	ap := NewStaticApprovers(o, nil)
 	for !ap.requirementsMet() {
 		newApprover := findMostCoveringApprover(potentialApprovers, reverseMap, ap.unapprovedFiles())
 		if newApprover == "" {
 			o.log.Warnf("Couldn't find/suggest approvers for each files. Unapproved: %q", ap.unapprovedFiles().UnsortedList())
 			return ap.getCurrentApproversSet()
 		}
-		ap.addApprover(newApprover)
+		ap.AddApprover(newApprover)
 	}
 	return ap.getCurrentApproversSet()
 }

--- a/prow/gitee-plugins/review-trigger/approvers/owners.go
+++ b/prow/gitee-plugins/review-trigger/approvers/owners.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package approvers
+
+import (
+	"math/rand"
+	"sort"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// Repo allows querying and interacting with OWNERS information in a repo.
+type Repo interface {
+	Approvers(path string) sets.String
+	LeafApprovers(path string) sets.String
+	FindApproverOwnersForFile(file string) string
+	IsNoParentOwners(path string) bool
+}
+
+// NewOwners consturcts a new Owners instance. filenames is the slice of files changed.
+func NewOwners(log *logrus.Entry, filenames []string, r Repo, s int64) Owners {
+	return Owners{filenames: filenames, repo: r, seed: s, log: log}
+}
+
+// Owners provides functionality related to owners of a specific code change.
+type Owners struct {
+	filenames []string
+	repo      Repo
+	seed      int64
+
+	log *logrus.Entry
+}
+
+// GetApprovers returns a map from ownersFiles -> people that are approvers in them
+func (o Owners) GetApprovers() map[string]sets.String {
+	ownersToApprovers := map[string]sets.String{}
+
+	for _, fn := range o.filenames {
+		ownersToApprovers[fn] = o.repo.Approvers(fn)
+	}
+
+	return ownersToApprovers
+}
+
+// GetLeafApprovers returns a map from ownersFiles -> people that are approvers in them (only the leaf)
+func (o Owners) GetLeafApprovers() map[string]sets.String {
+	ownersToApprovers := map[string]sets.String{}
+
+	for _, fn := range o.filenames {
+		ownersToApprovers[fn] = o.repo.LeafApprovers(fn)
+	}
+
+	return ownersToApprovers
+}
+
+// GetAllPotentialApprovers returns the people from relevant owners files needed to get the PR approved
+func (o Owners) GetAllPotentialApprovers() []string {
+	approversOnly := []string{}
+	for _, approverList := range o.GetLeafApprovers() {
+		approversOnly = append(approversOnly, approverList.List()...)
+	}
+
+	sort.Strings(approversOnly)
+
+	if len(approversOnly) == 0 {
+		o.log.Warn("No potential approvers exist. Does the repo have OWNERS files?")
+	}
+
+	return approversOnly
+}
+
+// temporaryUnapprovedFiles returns the list of files that wouldn't be
+// approved by the given set of approvers.
+func (o Owners) temporaryUnapprovedFiles(approvers sets.String) sets.String {
+	ap := NewApprovers(o)
+	for approver := range approvers {
+		ap.AddApprover(approver, "", false)
+	}
+	return ap.UnapprovedFiles()
+}
+
+// KeepCoveringApprovers finds who we should keep as suggested approvers given a pre-selection
+// knownApprovers must be a subset of potentialApprovers.
+func (o Owners) KeepCoveringApprovers(reverseMap map[string]sets.String, knownApprovers sets.String, potentialApprovers []string) sets.String {
+	if len(potentialApprovers) == 0 {
+		o.log.Debug("No potential approvers exist to filter for relevance. Does this repo have OWNERS files?")
+	}
+	keptApprovers := sets.NewString()
+
+	unapproved := o.temporaryUnapprovedFiles(knownApprovers)
+
+	for _, suggestedApprover := range o.GetSuggestedApprovers(reverseMap, potentialApprovers).List() {
+		if reverseMap[suggestedApprover].Intersection(unapproved).Len() != 0 {
+			keptApprovers.Insert(suggestedApprover)
+		}
+	}
+
+	return keptApprovers
+}
+
+func findMostCoveringApprover(allApprovers []string, reverseMap map[string]sets.String, unapproved sets.String) string {
+	maxCovered := 0
+	var bestPerson string
+	for _, approver := range allApprovers {
+		filesCanApprove := reverseMap[approver]
+		if filesCanApprove.Intersection(unapproved).Len() > maxCovered {
+			maxCovered = len(filesCanApprove)
+			bestPerson = approver
+		}
+	}
+	return bestPerson
+}
+
+// GetSuggestedApprovers solves the exact cover problem, finding an approver capable of
+// approving every OWNERS file in the PR
+func (o Owners) GetSuggestedApprovers(reverseMap map[string]sets.String, potentialApprovers []string) sets.String {
+	ap := NewApprovers(o)
+	for !ap.RequirementsMet() {
+		newApprover := findMostCoveringApprover(potentialApprovers, reverseMap, ap.UnapprovedFiles())
+		if newApprover == "" {
+			o.log.Warnf("Couldn't find/suggest approvers for each files. Unapproved: %q", ap.UnapprovedFiles().List())
+			return ap.GetCurrentApproversSet()
+		}
+		ap.AddApprover(newApprover, "", false)
+	}
+
+	return ap.GetCurrentApproversSet()
+}
+
+// GetShuffledApprovers shuffles the potential approvers so that we don't
+// always suggest the same people.
+func (o Owners) GetShuffledApprovers() []string {
+	approversList := o.GetAllPotentialApprovers()
+	order := rand.New(rand.NewSource(o.seed)).Perm(len(approversList))
+
+	people := make([]string, 0, len(approversList))
+	for _, i := range order {
+		people = append(people, approversList[i])
+	}
+	return people
+}
+
+// GetReverseMap returns a map from people -> OWNERS files for which they are an approver
+func GetReverseMap(approvers map[string]sets.String) map[string]sets.String {
+	approverOwnersfiles := map[string]sets.String{}
+	for ownersFile, approvers := range approvers {
+		for approver := range approvers {
+			if _, ok := approverOwnersfiles[approver]; ok {
+				approverOwnersfiles[approver].Insert(ownersFile)
+			} else {
+				approverOwnersfiles[approver] = sets.NewString(ownersFile)
+			}
+		}
+	}
+	return approverOwnersfiles
+}

--- a/prow/gitee-plugins/review-trigger/approvers/static_approvers.go
+++ b/prow/gitee-plugins/review-trigger/approvers/static_approvers.go
@@ -4,29 +4,29 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-type approversHelper struct {
+type StaticApprovers struct {
 	fileApprovers map[string]sets.String
 	approvers     sets.String
 }
 
-func newApproversHelper(o Owners, as []string) *approversHelper {
-	return &approversHelper{
+func NewStaticApprovers(o Owners, as []string) *StaticApprovers {
+	return &StaticApprovers{
 		fileApprovers: o.GetApprovers(),
 		approvers:     sets.NewString(as...),
 	}
 }
 
-func (ap *approversHelper) addApprover(a string) {
-	ap.approvers.Insert(a)
+func (ap *StaticApprovers) AddApprover(as ...string) {
+	ap.approvers.Insert(as...)
 }
 
-func (ap approversHelper) requirementsMet() bool {
+func (ap StaticApprovers) requirementsMet() bool {
 	return len(ap.fileApprovers) > 0 && ap.unapprovedFiles().Len() == 0
 }
 
-func (ap approversHelper) unapprovedFiles() sets.String {
+func (ap StaticApprovers) unapprovedFiles() sets.String {
 	unapproved := sets.NewString()
-	for fn, approvers := range ap.getFilesApprovers() {
+	for fn, approvers := range ap.GetFilesApprovers() {
 		if approvers.Len() == 0 {
 			unapproved.Insert(fn)
 		}
@@ -34,7 +34,7 @@ func (ap approversHelper) unapprovedFiles() sets.String {
 	return unapproved
 }
 
-func (ap approversHelper) getFilesApprovers() map[string]sets.String {
+func (ap StaticApprovers) GetFilesApprovers() map[string]sets.String {
 	currentApprovers := ap.getCurrentApproversSet()
 
 	filesApprovers := map[string]sets.String{}
@@ -44,6 +44,6 @@ func (ap approversHelper) getFilesApprovers() map[string]sets.String {
 	return filesApprovers
 }
 
-func (ap approversHelper) getCurrentApproversSet() sets.String {
+func (ap StaticApprovers) getCurrentApproversSet() sets.String {
 	return ap.approvers
 }

--- a/prow/gitee-plugins/review-trigger/approvers/static_approvers.go
+++ b/prow/gitee-plugins/review-trigger/approvers/static_approvers.go
@@ -1,8 +1,6 @@
 package approvers
 
-import (
-	"k8s.io/apimachinery/pkg/util/sets"
-)
+import "k8s.io/apimachinery/pkg/util/sets"
 
 type StaticApprovers struct {
 	fileApprovers map[string]sets.String
@@ -18,10 +16,6 @@ func NewStaticApprovers(o Owners, as []string) *StaticApprovers {
 
 func (ap *StaticApprovers) AddApprover(as ...string) {
 	ap.approvers.Insert(as...)
-}
-
-func (ap StaticApprovers) requirementsMet() bool {
-	return len(ap.fileApprovers) > 0 && ap.unapprovedFiles().Len() == 0
 }
 
 func (ap StaticApprovers) unapprovedFiles() sets.String {

--- a/prow/gitee-plugins/review-trigger/client.go
+++ b/prow/gitee-plugins/review-trigger/client.go
@@ -1,7 +1,6 @@
 package reviewtrigger
 
 import (
-	"path/filepath"
 	"time"
 
 	sdk "gitee.com/openeuler/go-gitee/gitee"
@@ -55,15 +54,9 @@ func (c ghclient) getPullRequestChanges(org, repo string, number int) ([]string,
 		return nil, err
 	}
 
-	m := map[string]bool{}
 	r := make([]string, 0, len(filenames))
 	for i := range filenames {
-		filename := filenames[i].Filename
-		dir := filepath.Dir(filename)
-		if !m[dir] {
-			m[dir] = true
-			r = append(r, filename)
-		}
+		r = append(r, filenames[i].Filename)
 	}
 	return r, nil
 }

--- a/prow/gitee-plugins/review-trigger/reviewer-helper.go
+++ b/prow/gitee-plugins/review-trigger/reviewer-helper.go
@@ -57,14 +57,7 @@ func (r reviewerHelper) suggestReviewers() ([]string, error) {
 
 func (r reviewerHelper) getReviewers(rc reviewersClient, files []string, minReviewers int, excludedReviewers sets.String) []string {
 	leafReviewers := sets.NewString()
-	ownersSeen := sets.NewString()
 	for _, filename := range files {
-		ownersFile := rc.FindReviewersOwnersForFile(filename)
-		if ownersSeen.Has(ownersFile) {
-			continue
-		}
-		ownersSeen.Insert(ownersFile)
-
 		v := rc.LeafReviewers(filename).Difference(excludedReviewers)
 		if v.Len() > 0 {
 			leafReviewers = leafReviewers.Union(v)
@@ -106,24 +99,18 @@ func popRandom(set *sets.String) string {
 	return sel
 }
 
-// findReviewer finds a reviewer from a set, potentially using status
-// availability.
+// findReviewer finds a reviewer from a set randomly.
 func findReviewer(targetSet *sets.String) string {
 	return popRandom(targetSet)
 }
 
 type reviewersClient interface {
-	FindReviewersOwnersForFile(path string) string
 	Reviewers(path string) sets.String
 	LeafReviewers(path string) sets.String
 }
 
 type fallbackReviewersClient struct {
 	oc repoowners.RepoOwner
-}
-
-func (foc fallbackReviewersClient) FindReviewersOwnersForFile(path string) string {
-	return foc.oc.FindApproverOwnersForFile(path)
 }
 
 func (foc fallbackReviewersClient) Reviewers(path string) sets.String {


### PR DESCRIPTION
This pr updates the algorithm of suggesting approvers and reviewers based on [file owners](https://github.com/opensourceways/test-infra/blob/593192b56c41862a7d0750689079949f5f5ca32b/prow/repoowners/repo_owners.md)

The lgtm, approve label will also be applied based on file owners.